### PR TITLE
Use quibble-with-apache entrypoint

### DIFF
--- a/workflow-templates/.github/workflows/mediawiki-tests.yml
+++ b/workflow-templates/.github/workflows/mediawiki-tests.yml
@@ -229,12 +229,6 @@ jobs:
             done
           fi
 
-          echo '?>' >> src/includes/DevelopmentSettings.php
-
-          curl -sL https://raw.githubusercontent.com/Universal-Omega/scripts/master/mediawiki/globals/fix-cache.php >> src/includes/DevelopmentSettings.php
-
-          echo '<?php' >> src/includes/DevelopmentSettings.php
-
           if [ -e "$GITHUB_WORKSPACE"/.github/workflows/globals.php ]; then
             echo 'require_once __DIR__ . "/../extensions/${{ github.event.repository.name }}/.github/workflows/globals.php";' >> src/includes/DevelopmentSettings.php
           fi
@@ -319,6 +313,7 @@ jobs:
               --color
           elif [ "${{ matrix.stage }}" == 'coverage' ] && [ -d src/extensions/"${{ github.event.repository.name }}"/tests/phpunit ]; then
             docker run \
+              --entrypoint quibble-with-apache \
               -e ZUUL_PROJECT=mediawiki/extensions/"${{ github.event.repository.name }}" \
               -v "$(pwd)"/cache:/cache \
               -v "$(pwd)"/src:/workspace/src \
@@ -329,6 +324,7 @@ jobs:
               -c mwext-phpunit-coverage
           elif [ "${{ matrix.stage }}" != 'coverage' ]; then
             docker run \
+              --entrypoint quibble-with-apache \
               -e ZUUL_PROJECT=mediawiki/extensions/"${{ github.event.repository.name }}" \
               -v "$(pwd)"/cache:/cache \
               -v "$(pwd)"/src:/workspace/src \

--- a/workflow-templates/.github/workflows/mediawiki-tests.yml
+++ b/workflow-templates/.github/workflows/mediawiki-tests.yml
@@ -233,10 +233,6 @@ jobs:
 
           curl -sL https://raw.githubusercontent.com/Universal-Omega/scripts/master/mediawiki/globals/fix-cache.php >> src/includes/DevelopmentSettings.php
 
-          if [ -d src/extensions/CreateWiki ] || [ "${{ github.event.repository.name }}" == 'CreateWiki' ]; then
-            curl -sL https://raw.githubusercontent.com/Universal-Omega/scripts/master/mediawiki/globals/setup-CreateWiki.php >> src/includes/DevelopmentSettings.php
-          fi
-
           echo '<?php' >> src/includes/DevelopmentSettings.php
 
           if [ -e "$GITHUB_WORKSPACE"/.github/workflows/globals.php ]; then

--- a/workflow-templates/.github/workflows/mediawiki-tests.yml
+++ b/workflow-templates/.github/workflows/mediawiki-tests.yml
@@ -229,6 +229,16 @@ jobs:
             done
           fi
 
+          echo '?>' >> src/includes/DevelopmentSettings.php
+
+          curl -sL https://raw.githubusercontent.com/Universal-Omega/scripts/master/mediawiki/globals/fix-cache.php >> src/includes/DevelopmentSettings.php
+
+          if [ -d src/extensions/CreateWiki ] || [ "${{ github.event.repository.name }}" == 'CreateWiki' ]; then
+            curl -sL https://raw.githubusercontent.com/Universal-Omega/scripts/master/mediawiki/globals/setup-CreateWiki.php >> src/includes/DevelopmentSettings.php
+          fi
+
+          echo '<?php' >> src/includes/DevelopmentSettings.php
+
           if [ -e "$GITHUB_WORKSPACE"/.github/workflows/globals.php ]; then
             echo 'require_once __DIR__ . "/../extensions/${{ github.event.repository.name }}/.github/workflows/globals.php";' >> src/includes/DevelopmentSettings.php
           fi


### PR DESCRIPTION
Fixes CI for usage with the latest quibble docker tag. The new tag makes the cache use memcached in CI, this causes errors with our CI, due to it not properly setting up and running the memcached instance. This entrypoint should do that, so supervisord is properly initialized, and memcached should run.