### PR TITLE
Add PHP 8.2 tests

### DIFF
--- a/workflow-templates/action.yml
+++ b/workflow-templates/action.yml
@@ -20,6 +20,13 @@ jobs:
             experimental: false
             stage: phan
 
+          # Latest stable MediaWiki - PHP 8.2 (phan)
+          - mw: 'REL1_39'
+            php: 8.2
+            php-docker: 82
+            experimental: false
+            stage: phan
+
           # Latest MediaWiki master - PHP 7.4 (phan)
           - mw: 'master'
             php: 7.4
@@ -27,10 +34,23 @@ jobs:
             experimental: true
             stage: phan
 
+          # Latest MediaWiki master - PHP 8.2 (phan)
+          - mw: 'master'
+            php: 8.2
+            php-docker: 82
+            experimental: true
+            stage: phan
+
           # Latest stable MediaWiki - PHP 7.4 (phpunit)
           - mw: 'REL1_39'
             php: 7.4
             php-docker: 74
+            experimental: false
+            stage: phpunit
+          # Latest stable MediaWiki - PHP 8.2 (phpunit)
+          - mw: 'REL1_39'
+            php: 8.2
+            php-docker: 82
             experimental: false
             stage: phpunit
 
@@ -41,10 +61,10 @@ jobs:
             experimental: true
             stage: phpunit
 
-          # Latest MediaWiki master - PHP 8.1 (phpunit)
+          # Latest MediaWiki master - PHP 8.2 (phpunit)
           - mw: 'master'
-            php: 8.1
-            php-docker: 81
+            php: 8.2
+            php-docker: 82
             experimental: true
             stage: phpunit
 
@@ -55,10 +75,24 @@ jobs:
             experimental: false
             stage: selenium
 
+          # Latest stable MediaWiki - PHP 8.2 (selenium)
+          - mw: 'REL1_39'
+            php: 8.2
+            php-docker: 82
+            experimental: false
+            stage: selenium
+
           # Latest MediaWiki master - PHP 7.4 (selenium)
           - mw: 'master'
             php: 7.4
             php-docker: 74
+            experimental: true
+            stage: selenium
+
+          # Latest MediaWiki master - PHP 8.2 (selenium)
+          - mw: 'master'
+            php: 8.2
+            php-docker: 82
             experimental: true
             stage: selenium
 
@@ -69,10 +103,24 @@ jobs:
             experimental: false
             stage: qunit
 
+          # Latest stable MediaWiki - PHP 8.2 (qunit)
+          - mw: 'REL1_39'
+            php: 8.2
+            php-docker: 82
+            experimental: false
+            stage: qunit
+
           # Latest MediaWiki master - PHP 7.4 (qunit)
           - mw: 'master'
             php: 7.4
             php-docker: 74
+            experimental: false
+            stage: qunit
+
+          # Latest MediaWiki master: PHP 8.2 (qunit)
+          - mw: 'master'
+            php: 8.2
+            php-docker: 82
             experimental: false
             stage: qunit
 
@@ -82,11 +130,25 @@ jobs:
             php-docker: 74
             experimental: false
             stage: npm-test
-  
+
+          # Latest stable MediaWiki - PHP 8.2 (npm-test)
+          - mw: 'REL1_39'
+            php: 8.2
+            php-docker: 82
+            experimenta: false
+            stage: npm-test
+
           # Latest stable MediaWiki - PHP 7.4 (composer-test)
           - mw: 'REL1_39'
             php: 7.4
             php-docker: 74
+            experimental: false
+            stage: composer-test
+
+          # Latest stable MediaWiki - PHP 8.2 (composer-test)
+          - mw: 'REL1_39'
+            php: 8.2
+            php-docker: 82
             experimental: false
             stage: composer-test
 


### PR DESCRIPTION
In preparation for Debian Bookworm's release as the new stable, we should test for PHP 8.2. For now, we should test both 7.4 and 8.2 at the same time, but once Bookworm becomes stable, we remove 7.4